### PR TITLE
Initial repo structure, README, and .gitignore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+- What does this PR change?
+
+## Type
+- [ ] feat
+- [ ] fix
+- [ ] docs
+- [ ] refactor
+- [ ] test
+- [ ] chore
+
+## Testing
+- How did you test it?
+
+## Checklist
+- [ ] Linked issue(s)
+- [ ] Added/updated docs if needed
+- [ ] Tagged **2 reviewers**

--- a/.gitignore.txt
+++ b/.gitignore.txt
@@ -1,0 +1,23 @@
+# OS files
+.DS_Store
+Thumbs.db
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/
+.mypy_cache/
+.pytest_cache/
+
+# Node/Frontend
+node_modules/
+dist/
+build/
+.coverage
+.vite
+.next
+
+# Env files
+.env
+.env.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Branching
+- Only `main` and `dev` exist in upstream.
+- All contributors work on **forks**:
+  - Feature branches: `feature/<short-name>`
+  - Fix branches: `fix/<short-name>`
+  - Docs branches: `docs/<short-name>`
+
+## PR Rules
+- Target branch: `dev`
+- Mark WIP PRs with `WIP:` prefix or draft PRs
+- Tag **at least 2 reviewers** before merge
+- Link issue(s) and add a brief summary + test notes
+
+## Naming Conventions
+- Folders/files: `kebab-case`
+- Python: `snake_case` for files/functions; `PascalCase` classes
+- JS/TS: `kebab-case` files; `camelCase` vars; `PascalCase` components
+
+## Commits
+- Conventional style (recommended):
+  - `feat: …`, `fix: …`, `docs: …`, `refactor: …`, `test: …`, `chore: …`
+
+## Frontend vs Backend
+- Frontend code → `frontend/`
+- Backend code → `backend/`
+- Shared code/assets only if truly reused → `shared/`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # design-engineering
-Central repository for the Product Design and Engineering Team, focused on designing user experiences, building system architecture, and integrating front-end and back-end components. Includes design assets, wireframes, prototypes, code, and technical documentation.
+## Monorepo layout
+- `frontend/` – UI app (React/Streamlit)
+- `backend/` – FastAPI services & APIs
+- `shared/` – shared modules/assets (optional)
+
+## Branching model
+- `main` – protected, production-ready
+- `dev` – integration branch
+- Feature work happens on forks → PR → `dev`
+
+## Conventions
+- Folders/files: `kebab-case` (e.g., `submission-service`)
+- Python: modules `snake_case.py`, classes `PascalCase`
+- JS/TS: files `kebab-case`, variables `camelCase`
+
+See `CONTRIBUTING.md` for workflow & PR rules.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# Backend
+Tech: FastAPI.
+Endpoints, env, and run instructions will go here.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+Tech: React/Streamlit (TBD).
+Run, env, and build instructions will go here.

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,2 @@
+# Shared
+Only create/keep this folder if shared code/assets are used.


### PR DESCRIPTION
## Summary
- Added initial folder structure: `/frontend`, `/backend`, `/shared`
- Added `.gitignore` for common files and environment configs
- Created base `README.md` with usage and contribution guidelines
- Added `PULL_REQUEST_TEMPLATE.md` for consistent PR reviews

### Notes
- Please review folder naming conventions and suggest changes if needed